### PR TITLE
Remove dark mode toggle and enforce dark-only theme

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -7,7 +7,7 @@ tags: [welcome, about, digital-garden]
 
 # Hello, I'm Nehal (pronounced _næhāl_)
 
-Currently working on eval at [CodeRabbit.ai](https://coderabbit.ai), evaluating how rabbits hop.
+Currently working on eval at [CodeRabbit.ai](https://coderabbit.ai), evaluating rabbits' hops.
 
 🧠 **[[papers/|Research & Papers]]** - AI, machine learning, and interpretability research
 
@@ -18,7 +18,5 @@ Currently working on eval at [CodeRabbit.ai](https://coderabbit.ai), evaluating 
 🦙 **[[llama/|LLaMA & Language Models]]** - Large language model experiments
 
 🔍 **[[interpretability/|AI Interpretability]]** - Understanding how AI systems work
-
----
 
 _Managed by [Claude Code](https://claude.ai/code)_

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -19,7 +19,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
-    Component.Darkmode(),
     Component.DesktopOnly(Component.Explorer()),
   ],
   right: [
@@ -35,7 +34,6 @@ export const defaultListPageLayout: PageLayout = {
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
-    Component.Darkmode(),
     Component.DesktopOnly(Component.Explorer()),
   ],
   right: [],

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -19,6 +19,18 @@ section {
   color: var(--darkgray);
 }
 
+// Force dark mode
+:root {
+  --light: #161618;
+  --lightgray: #393639;
+  --gray: #646464;
+  --darkgray: #d4d4d4;
+  --dark: #ebebec;
+  --secondary: #7b97aa;
+  --tertiary: #84a59d;
+  --highlight: rgba(143, 159, 169, 0.15);
+}
+
 .text-highlight {
   background-color: #fff23688;
   padding: 0 0.1rem;


### PR DESCRIPTION
## Summary
- Removed dark mode toggle component from both content and list page layouts for cleaner interface
- Enforced dark-only theme by overriding CSS variables in base styles
- Fixed content typo and removed unnecessary formatting

## Test plan
- [ ] Verify dark mode is enforced across all pages
- [ ] Confirm toggle component is removed from layout
- [ ] Check homepage content displays correctly
- [ ] Test responsive behavior on mobile/desktop

🤖 Generated with [Claude Code](https://claude.ai/code)